### PR TITLE
workflows: add arm container images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,19 +41,22 @@ jobs:
         username: deyaeddin
         password: ${{ secrets.DOCKER_TOKEN }}
     -
-      name: Build release
-      if: ${{ steps.version.outputs.version != '' }}
-      run: make build IMAGE_TAG="${{ steps.version.outputs.version }}"
+      name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: deyaeddin/cert-manager-webhook-hetzner
+        tags: |
+          type=raw,value=${{ steps.version.outputs.version }}
+          type=raw,value=latest
     -
-      name: Push image release
-      if: ${{ steps.version.outputs.version != '' }}
-      run: make push-release IMAGE_TAG="${{ steps.version.outputs.version }}"
-    -
-      name: Build Edge
-      run: make build-edge
-    -
-      name: Push Edge
-      run: make push-edge
+      name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm/v7,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
   # --------------------------------------------------------------------------------
     -
       name: Install helm


### PR DESCRIPTION
Switch from Makefile to Docker actions.
Add armv7 and arm64 platforms to the build action.

I'm currently running the arm64 build on a raspberry pi 4b without issues.