### PR TITLE
Set App Version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         HELM_REPO: docs/chart
         CHART_DIR: charts/cert-manager-webhook-hetzner/
       run: |
-        helm package "${CHART_DIR}" -d "${HELM_REPO}" --version "${{ steps.version.outputs.version }}"
+        helm package "${CHART_DIR}" -d "${HELM_REPO}" --version "${{ steps.version.outputs.version }}" --app-version "${{ steps.version.outputs.version }}"
     -
       name: Index Helm Charts
       if: ${{ steps.version.outputs.version != '' }}

--- a/charts/cert-manager-webhook-hetzner/Chart.yaml
+++ b/charts/cert-manager-webhook-hetzner/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
-appVersion: 1.1.0
+appVersion: 0.0.1 # dummy value, set with helm package
 name: cert-manager-webhook-hetzner
 description: Allow cert-manager to solve DNS challenges using Hetzner DNS API
 icon: https://res.cloudinary.com/deyaeddin/image/upload/v1621402563/projects/webhook_vdwtdl.png
 home: https://deyaeddin.github.io/cert-manager-webhook-hetzner/chart/
 sources:
   - https://github.com/deyaeddin/cert-manager-webhook-hetzner
-version: 1.1.0
+version: 0.0.1 # dummy value, set with helm package
 type: application
 keywords:
   - cert-manager

--- a/charts/cert-manager-webhook-hetzner/values.yaml
+++ b/charts/cert-manager-webhook-hetzner/values.yaml
@@ -15,7 +15,6 @@ certManager:
 
 image:
   repository: deyaeddin/cert-manager-webhook-hetzner
-  tag: latest
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
Right now the image tag pulled by kubernetes defaults to `latest`, with the image pull policy `IfNotPresent` this leads to the image not being updated. This PR fixes this by dropping the image tag from the values file and updating the `appVresion` to the container image tag when packaging the helm chart. 

I am not exactly sure what the next tag should be since the artifact hub shows an app version of `1.1.0`. Either break with semver and just use `0.2.x` or bump everything to `2.x`. If you think the appVersion should be set some other way let me know. 