### PR TITLE
Add minutes and seconds to certificate lifetimes.

### DIFF
--- a/charts/cert-manager-webhook-hetzner/templates/pki.yaml
+++ b/charts/cert-manager-webhook-hetzner/templates/pki.yaml
@@ -29,7 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-hetzner.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "cert-manager-webhook-hetzner.selfSignedIssuer" . }}
   commonName: "ca.cert-manager-webhook-hetzner.cert-manager"
@@ -67,7 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-hetzner.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "cert-manager-webhook-hetzner.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
Adding minutes and seconds to certificate lifetimes, matching the format kubernetes uses internally. Without this, tools like ArgoCD always show a drift between the templates resource and the actual resource.

Example in ArgoCD diff:
![grafik](https://user-images.githubusercontent.com/23323185/209468265-8045067c-fc30-4e3f-a945-5157a5ba98c3.png)